### PR TITLE
リファクタリングなど

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,18 +167,3 @@ getval.sh data/input.qasm data/gv_kekka.txt data/fermion.txt
 qulacs と、qulacs-osaka にプルリクを投げました。
 
 通れば、入力 QASM ファイルの bit 数が、fermion のビット数以上なら動くようになります。
-
-## re_simulate.sh
-
-`re_simulate.sh 出力.txt shot回数`
-
-## re_getval.sh
-
-`re_getval.sh 出力.txt openfermion_file`
-
-この 2 つは、QASM ファイルは前回入力したものを使う場合のコマンドです。
-
-具体的にいうと、re\_ が付かないシェルでは、staq を用いて入力したファイルを qulacs が処理しやすい形式にした後、data/cpl.qasm に保存されています。
-その data/cpl.qasm を、再び使います。
-
-trance.sh でも cpl.qasm は更新されます。

--- a/getval.sh
+++ b/getval.sh
@@ -1,3 +1,7 @@
-staq -m --evaluate-all $1 > data/cpl.qasm
+#!/bin/bash
 
-poetry run python ouqu_tp/getval.py $3 < data/cpl.qasm > $2
+workdir=$(mktemp -d)
+
+staq -m --evaluate-all $1 > $workdir/cpl.qasm
+
+poetry run python ouqu_tp/getval.py $3 < $workdir/cpl.qasm > $2

--- a/re_getval.sh
+++ b/re_getval.sh
@@ -1,1 +1,0 @@
-poetry run python ouqu_tp/getval.py $12 < data/cpl.qasm > $1

--- a/re_simulate.sh
+++ b/re_simulate.sh
@@ -1,1 +1,0 @@
-poetry run python ouqu_tp/simulate.py $2 < data/cpl.qasm > $1

--- a/simulate.sh
+++ b/simulate.sh
@@ -1,3 +1,7 @@
-staq -m --evaluate-all $1 > data/cpl.qasm
+#!/bin/bash
 
-poetry run python ouqu_tp/simulate.py $3 < data/cpl.qasm > $2
+workdir=$(mktemp -d)
+
+staq -m --evaluate-all $1 > $workdir/cpl.qasm
+
+poetry run python ouqu_tp/simulate.py $3 < $workdir/cpl.qasm > $2

--- a/trance.sh
+++ b/trance.sh
@@ -1,5 +1,9 @@
-poetry run python ouqu_tp/make_Cnet.py < $2 > data/created_Cnet.json
+#!/bin/bash
 
-staq -S -O2 -m -d data/created_Cnet.json --evaluate-all $1 > data/cpl.qasm
+workdir=$(mktemp -d)
 
-poetry run python ouqu_tp/trancepile.py < data/cpl.qasm > $3
+poetry run python ouqu_tp/make_Cnet.py < $2 > $workdir/created_Cnet.json
+
+staq -S -O2 -m -d $workdir/created_Cnet.json --evaluate-all $1 > $workdir/cpl.qasm
+
+poetry run python ouqu_tp/trancepile.py < $workdir/cpl.qasm > $3


### PR DESCRIPTION
closing #11 

# 概要
シェルスクリプトについて、従来の手法では生成したいファイルの他にも作業用ファイルが同時に生成されるという問題がありました。この挙動は利用者にとって混乱を招く原因となります。

そこで、mktempコマンドを使って利用者から見えない位置に一時ファイル置き場を作り、そこに作業用ファイルを置くようにしました。


また、re_\*と名前が付いているシェルスクリプトは全て削除しました。これは暗黙的に作業用ファイルを指定しているのと同等であり、コマンドの実行順序によって動作が変わってしまうからです。コマンドに指定していないファイルの状態によって挙動が変化するというのは利用者にとって混乱を招きます。