### PR TITLE
cswapを削除

### DIFF
--- a/qelib_tuika.txt
+++ b/qelib_tuika.txt
@@ -8,13 +8,6 @@ gate sx a { sdg a; h a; sdg a; }
 // inverse sqrt(X)
 gate sxdg a { s a; h a; s a; }
 
-// cswap (Fredkin)
-gate cswap a,b,c
-{
-cx c,b;
-ccx a,b,c;
-cx c,b;
-}
 // controlled rx rotation
 gate crx(lambda) a,b
 {


### PR DESCRIPTION
#44 の修正です。
cswapが二重定義になるため外しました。